### PR TITLE
Fix lack of htmlSnippet

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,2 +1,3 @@
 v0.1.0, 2019-07-19 -- Create the extension from code in docs.snapcraft.io
 v0.2.0, 2019-08-28 -- Support for siteSearch param
+v0.2.1, 2020-02-05 -- Fix error with lacking htmlSnippet in results

--- a/canonicalwebteam/search/models.py
+++ b/canonicalwebteam/search/models.py
@@ -37,6 +37,7 @@ def get_search_results(
 
         # Remove newlines from the snippet
         for item in results["entries"]:
-            item["htmlSnippet"] = item["htmlSnippet"].replace("<br>\n", "")
+            if "htmlSnippet" in item:
+                item["htmlSnippet"] = item["htmlSnippet"].replace("<br>\n", "")
 
     return results

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.search",
-    version="0.2.0",
+    version="0.2.1",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical-web-and-design/canonicalwebteam.search",


### PR DESCRIPTION
This will fix this error:
https://github.com/canonical-web-and-design/ubuntu.com/issues/6566
which we were seeing on:
https://ubuntu.com/search?q=kernel

QA
--

Get the search API key from here:
https://console.cloud.google.com/apis/credentials?project=ubuntu-search-1530889417216
to use in the QAing:

``` bash
cd ..  # One level up from this PR
git clone git@github.com:canonical-web-and-design/ubuntu.com
cd ubuntu.com
python3 -m venv env3
source env3/bin/activate
pip3 install -r requirements.txt
SEARCH_API_KEY=xxxx ./entrypoint 0.0.0.0:8001
```

Go to http://0.0.0.0:8001/search?q=kernel, see 500 page.

``` bash
pip3 uninstall -y canonicalwebteam.search
pip3 install -e ../canonicalwebteam.search  # Where you checked out this PR
SEARCH_API_KEY=xxxx ./entrypoint 0.0.0.0:8001
```

Go to http://0.0.0.0:8001/search?q=kernel, see it works.