### PR TITLE
Allow argument search_engine_id to be changed

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
 v0.1.0, 2019-07-19 -- Create the extension from code in docs.snapcraft.io
 v0.2.0, 2019-08-28 -- Support for siteSearch param
 v0.2.1, 2020-02-05 -- Fix error with lacking htmlSnippet in results
+v0.3.0, 2020-02-05 -- Allow argument search_engine_id or cx to be changed

--- a/canonicalwebteam/search/views.py
+++ b/canonicalwebteam/search/views.py
@@ -12,11 +12,20 @@ class NoAPIKeyError(Exception):
     pass
 
 
-def build_search_view(site=None, template_path="search.html"):
+def build_search_view(
+    search_engine_id="009048213575199080868:i3zoqdwqk8o",
+    template_path="search.html",
+    site=None,
+):
     """
     Build and return a view function that will query the
     Google Custom Search API and then render search results
     using the provided template.
+
+    According to Google Custom API, `siteSearch` is optional.
+    https://developers.google.com/custom-search/v1/using_rest#making_a_request
+    Therefore, the scope of the search is determined by
+    the cx (Search engine ID), this ID is public
 
     Usage in e.g. `app.py`:
 
@@ -27,7 +36,7 @@ def build_search_view(site=None, template_path="search.html"):
             "/search",
             "search",
             build_search_view(
-                site="snapcraft.io",
+                search_engine_id="009048213575199080868:i3zoqdwqk8o",
                 template_path="search.html"
             )
         )
@@ -37,9 +46,6 @@ def build_search_view(site=None, template_path="search.html"):
         """
         Get search results from Google Custom Search
         """
-
-        # The webteam's default custom search ID
-        search_engine_id = "009048213575199080868:i3zoqdwqk8o"
 
         # API key should always be provided as an environment variable
         search_api_key = os.getenv("SEARCH_API_KEY")

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.search",
-    version="0.2.1",
+    version="0.3.0",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical-web-and-design/canonicalwebteam.search",


### PR DESCRIPTION
## Summary
- Search scope of Google Customer search is restricted by the search engine id, so for sites created using certain ID you can only search in that site.
- Refactored so that this cx/search engine ID can be passed.