### PR TITLE
Add all necessary imports to usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Or add `canonicalwebteam.search` to your `requirements.txt`.
 You can add the extension on your project's application as follows:
 
 ``` python3
+import talisker.requests
+from flask import Flask
 from canonicalwebteam.search import build_search_view
 
 app = Flask("myapp")


### PR DESCRIPTION
Usage example in README doesn't show the imports for Flask and talisker.requests, so it hard to know how to fully use search without looking for examples in other projects.