### PR TITLE
Set noindex for crawlers

### DIFF
--- a/canonicalwebteam/search/views.py
+++ b/canonicalwebteam/search/views.py
@@ -71,13 +71,23 @@ def build_search_view(
                 num=num,
             )
 
-        return flask.render_template(
-            template_path,
-            query=query,
-            start=start,
-            num=num,
-            results=results,
-            siteSearch=site_search,
-        )
+            return flask.render_template(
+                template_path,
+                query=query,
+                start=start,
+                num=num,
+                results=results,
+                siteSearch=site_search,
+            ), {"X-Robots-Tag": "noindex"}
+
+        else:
+            return flask.render_template(
+                template_path,
+                query=query,
+                start=start,
+                num=num,
+                results=results,
+                siteSearch=site_search,
+            )
 
     return search_view


### PR DESCRIPTION
## Done

Set noindex to headers, so that search crawlers don't index search pages

## QA

- Use https://github.com/canonical-web-and-design/ubuntu.com/pull/11744 to test (search needs to be added back)
- `curl -I http://localhost:8001/server/docs/search?q=application&siteSearch=https%3A%2F%2Fubuntu.com%2Fserver%2Fdocs` it should show `X-Robots-Tag: none` among the headers. For reference check [google guide](https://developers.google.com/search/docs/advanced/robots/robots_meta_tag)
- To check that other pages do not have this `curl -I localhost:8001` and the previous header should not exist
## Issue

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5554#event-6838547555