### PR TITLE
Block search bots

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,3 +3,4 @@ v0.2.0, 2019-08-28 -- Support for siteSearch param
 v0.2.1, 2020-02-05 -- Fix error with lacking htmlSnippet in results
 v1.0.0, 2021-02-23 -- Insist on being passed a request session instead of using canonicalwebteam.http
 v1.2.0, 2021-04-11 -- Add optional site restricted search
+v1.2.0, 2021-04-11 -- Block results pages from being indexed; block bots from using search API

--- a/canonicalwebteam/search/views.py
+++ b/canonicalwebteam/search/views.py
@@ -3,6 +3,7 @@ import os
 
 # Packages
 import flask
+import user_agents
 
 # Local
 from canonicalwebteam.search.models import get_search_results
@@ -60,6 +61,13 @@ def build_search_view(
         results = None
 
         if query:
+            agent = user_agents.parse(str(flask.request.user_agent))
+
+            # Block search bots
+            # So we don't pay for their API calls
+            if agent.is_bot:
+                flask.abort(403)
+
             results = get_search_results(
                 session=session,
                 api_key=search_api_key,

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,6 @@ setup(
     packages=find_packages(),
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
-    install_requires=["Flask>=1.0.2"],
+    install_requires=["Flask>=1.0.2", "user-agents>=2.0.0"],
     tests_require=["httpretty"],
 )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.search",
-    version="1.2.0",
+    version="1.2.1",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical-web-and-design/canonicalwebteam.search",


### PR DESCRIPTION
Prevent search robots from triggering Google Programmable Search API calls.

This will return a 403 page to any client that declares itself as a robot through the user-agent string. (Note this would not block malicious attacks, only honest bots).

### Background

We believe the massive spike in our Programmable Search API usage is because a couple of our search results pages got indexed by Google and ended up being crawled by search robots a lot:

- [server docs search](https://www.google.com/search?q=%22ubuntu.com%2Fserver%2Fdocs%2Fsearch%3Fq%3D%22+-site%3Aubuntu.com)
-  [tutorials search](https://www.google.com/search?q=%22ubuntu.com%2Ftutorials%3Fq%3D%22+-site%3Aubuntu.com)

<details>
<summary>server search google results screenshot</summary>
<img src="https://user-images.githubusercontent.com/519935/175307609-ef21831a-b9c2-465d-9401-3ef7e531398c.png" />
</details>

<details>
<summary>tutorials search google results screenshot</summary>
<img src="https://user-images.githubusercontent.com/519935/175306754-f68d1344-1cb2-4b07-bd5c-612399c1010e.png" />
</details>

This theory is backed up by the very large growth in indexed pages [in the Google Search Console](https://search.google.com/search-console/index/drilldown?resource_id=https%3A%2F%2Fubuntu.com%2F&item_key=CAMYAiAB), which appears to have happened just before we started to see issues.

<details>
<summary>Google index graph screenshot</summary>
<img src="https://user-images.githubusercontent.com/519935/175308342-1d96a3f8-8e5c-410d-9f73-3008436fb225.png">
</details>

We also recently re-enabled all searches except for tutorials and server. And so far, after about 4 hours, we've had less than 600 search requests. From looking at [the cloud console](https://console.cloud.google.com/apis/api/customsearch.googleapis.com/metrics?project=ubuntu-search-1530889417216&pageState=(%22duration%22:(%22groupValue%22:%22PT6H%22,%22customValue%22:null))), it looks like we'll be comfortably under the 10,000 limit.

<details>
<summary>Cloud console API graph</summary>
<img src="https://user-images.githubusercontent.com/519935/175310627-0ee8b4a7-4550-4fdd-82db-ef751bc1df30.png">
</details>

Fixes https://github.com/canonical/Web-design-systems-squad/issues/9

# QA

First check requests that don't explicitly declare themselves as a bot will succeed. Check you see `200 OK`:

``` bash
$ curl -I http://0.0.0.0:8001/search?q=hello
HTTP/1.1 200 OK
Server: gunicorn
...
```

Now send a bot user-agent - e.g. one from [the Google list of search bot user agents](https://developers.google.com/search/docs/advanced/crawling/overview-google-crawlers) - check you see `403 FORBIDDEN`:

``` bash
$ curl -I --user-agent "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Googlebot/2.1; +htt
p://www.google.com/bot.html) Chrome/W.X.Y.Z Safari/537.36" http://0.0.0.0:8001/search?q=hello
HTTP/1.1 403 FORBIDDEN
Server: gunicorn
...
```
