### PR TITLE
Block spam by detecting a character or two

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,4 +3,5 @@ v0.2.0, 2019-08-28 -- Support for siteSearch param
 v0.2.1, 2020-02-05 -- Fix error with lacking htmlSnippet in results
 v1.0.0, 2021-02-23 -- Insist on being passed a request session instead of using canonicalwebteam.http
 v1.2.0, 2021-04-11 -- Add optional site restricted search
-v1.2.0, 2021-04-11 -- Block results pages from being indexed; block bots from using search API
+v1.2.1, 2022-06-23 -- Block results pages from being indexed; block bots from using search API
+v1.2.2, 2022-07-06 -- Block searches with weird characters in them

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.search",
-    version="1.2.1",
+    version="1.2.2",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical-web-and-design/canonicalwebteam.search",


### PR DESCRIPTION
I spend a while looking through the logs of the spam search requests we've been getting recently - e.g. with [this search](https://logging.comms.canonical.com/search?width=1852&relative=604800&page=35&sortOrder=desc&q=querystring%3A%20q%3D%2A%20AND%20path%3A%20%5C%2Fserver%5C%2Fdocs%5C%2Fsearch&rangetype=relative&fields=source%2Chttpstatus%2Cip_extracted%2Cmessage%2Cpath%2Cquerystring&sortField=timestamp) (must be logged into greylog before clicking the link).

Initially I was planning to block spam, fundamentally, by checking whether the IPs were in spam blacklists (e.g. [here](https://mxtoolbox.com/blacklists.aspx). But when I looked, most spam searches were actually from IPs that weren't actually detected as spam IPs.

So I looked through the searches to see what other commonalities they had. What I've landed on is simply the existence of "【", "】" characters. These characters are weird and I can't imagine why a real person would include them in a search.

So I'm just going to block searches that include these characters. I hope that will mostly work.